### PR TITLE
Fix bcrypt compatibility by using bcrypt directly instead of passlib

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -3,8 +3,8 @@
 import os
 from datetime import datetime, timedelta
 
+import bcrypt as _bcrypt
 from jose import JWTError, jwt
-from passlib.hash import bcrypt
 
 SECRET_KEY = os.environ.get("APPROV_SECRET_KEY", "dev-secret-key-change-in-production")
 ALGORITHM = "HS256"
@@ -12,11 +12,11 @@ ACCESS_TOKEN_EXPIRE_HOURS = 24
 
 
 def hash_password(password: str) -> str:
-    return bcrypt.hash(password)
+    return _bcrypt.hashpw(password.encode("utf-8"), _bcrypt.gensalt()).decode("utf-8")
 
 
 def verify_password(password: str, password_hash: str) -> bool:
-    return bcrypt.verify(password, password_hash)
+    return _bcrypt.checkpw(password.encode("utf-8"), password_hash.encode("utf-8"))
 
 
 def create_access_token(user_id: int, username: str, roles: list[str]) -> str:

--- a/approv/db.py
+++ b/approv/db.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
-from passlib.hash import bcrypt
+import bcrypt
 
 logger = logging.getLogger(__name__)
 
@@ -283,7 +283,7 @@ def _seed_data(conn: sqlite3.Connection, config_dir: str):
     user_map = {}  # username -> user_id
     for username, user_data in data.get("User", {}).items():
         # Default password is lowercase username
-        password_hash = bcrypt.hash(username.lower())
+        password_hash = bcrypt.hashpw(username.lower().encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
         conn.execute(
             "INSERT OR IGNORE INTO users (username, email, phone, password_hash) VALUES (?, ?, ?, ?)",
             (username, user_data.get("email", ""), user_data.get("phone", ""), password_hash),

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 fastapi
 uvicorn[standard]
 python-jose[cryptography]
-passlib[bcrypt]
+bcrypt
 httpx
 
 # Client


### PR DESCRIPTION
passlib has a known incompatibility with newer bcrypt versions (missing __about__ attribute). Switch to using the bcrypt library directly for password hashing and verification.