### PR TITLE
Add future annotations for Python 3.9 compatibility

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,5 +1,7 @@
 """JWT authentication utilities."""
 
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,5 +1,7 @@
 """FastAPI dependencies for auth and database access."""
 
+from __future__ import annotations
+
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,7 @@
 """FastAPI application entrypoint."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/api/routers/admin_router.py
+++ b/api/routers/admin_router.py
@@ -1,5 +1,7 @@
 """Admin endpoints: workflow definitions, user/role CRUD, DB backup/export/import."""
 
+from __future__ import annotations
+
 import json
 import os
 

--- a/api/routers/auth_router.py
+++ b/api/routers/auth_router.py
@@ -1,5 +1,7 @@
 """Authentication endpoints."""
 
+from __future__ import annotations
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from api.auth import create_access_token, verify_password

--- a/api/routers/form_router.py
+++ b/api/routers/form_router.py
@@ -1,5 +1,7 @@
 """Form specification endpoint - the key thin-client endpoint."""
 
+from __future__ import annotations
+
 import json
 import os
 

--- a/api/routers/tasks_router.py
+++ b/api/routers/tasks_router.py
@@ -1,5 +1,7 @@
 """Task views - pending items and workflow history."""
 
+from __future__ import annotations
+
 from fastapi import APIRouter, Depends, Query
 
 from api.dependencies import get_current_user, get_db

--- a/api/routers/workflow_router.py
+++ b/api/routers/workflow_router.py
@@ -1,5 +1,7 @@
 """Workflow instance endpoints."""
 
+from __future__ import annotations
+
 import json
 
 import yaml

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,5 +1,7 @@
 """API request/response Pydantic schemas."""
 
+from __future__ import annotations
+
 from pydantic import BaseModel
 from typing import Any, Optional
 

--- a/approv/db.py
+++ b/approv/db.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sqlite3
 import os
 import json

--- a/approv/engine.py
+++ b/approv/engine.py
@@ -4,6 +4,8 @@ Workflow engine - decoupled from any UI framework.
 Manages workflow state machine execution, audit trail, and permission checking.
 """
 
+from __future__ import annotations
+
 import json
 import logging
 from datetime import datetime

--- a/approv/form_spec.py
+++ b/approv/form_spec.py
@@ -5,6 +5,8 @@ Produces a FormSpec JSON structure from YAML config, form data, and user roles.
 Zero Streamlit imports - this is a pure data transformation.
 """
 
+from __future__ import annotations
+
 import yaml
 from datetime import date, datetime, time
 

--- a/approv/models.py
+++ b/approv/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel
 from typing import Any, Optional
 from datetime import datetime

--- a/approv/steps.py
+++ b/approv/steps.py
@@ -7,6 +7,8 @@ Each step class follows the contract:
         Returns (next_status, description)
 """
 
+from __future__ import annotations
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/approv/validation.py
+++ b/approv/validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import yaml
 

--- a/client/api_client.py
+++ b/client/api_client.py
@@ -1,5 +1,7 @@
 """HTTP client wrapper for the ApproV API."""
 
+from __future__ import annotations
+
 import requests
 from typing import Any
 

--- a/client/form_renderer.py
+++ b/client/form_renderer.py
@@ -3,6 +3,8 @@ Generic form renderer: takes a FormSpec JSON from the API and renders Streamlit 
 This module has zero knowledge of workflow logic - it just renders what the API tells it.
 """
 
+from __future__ import annotations
+
 import streamlit as st
 from datetime import datetime, date, time
 


### PR DESCRIPTION
The `X | Y` union syntax and `list[x]`, `dict[x, y]` generics require Python 3.10+. Adding `from __future__ import annotations` to all modules makes these work on Python 3.9 by deferring annotation evaluation.